### PR TITLE
Update CI to fail on "warning"

### DIFF
--- a/docs/lit/demos/01/dot.jl
+++ b/docs/lit/demos/01/dot.jl
@@ -9,7 +9,7 @@ using the Julia language.
 #srcURL
 
 #=
-First we add the Julia packages that are need for this demo.
+Add the Julia packages that are need for this demo.
 Change `false` to `true` in the following code block
 if you are using any of the following packages for the first time.
 =#
@@ -25,7 +25,7 @@ if false
 end
 
 
-# Now tell this Julia session to use the following packages for this example.
+# Tell this Julia session to use the following packages for this example.
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
 using BenchmarkTools: @benchmark

--- a/docs/lit/demos/01/mul-mat-vec.jl
+++ b/docs/lit/demos/01/mul-mat-vec.jl
@@ -9,7 +9,7 @@ using the Julia language.
 #srcURL
 
 #=
-First we add the Julia packages that are need for this demo.
+Add the Julia packages that are need for this demo.
 Change `false` to `true` in the following code block
 if you are using any of the following packages for the first time.
 =#
@@ -23,7 +23,7 @@ if false
 end
 
 
-# Now tell this Julia session to use the following packages for this example.
+# Tell this Julia session to use the following packages for this example.
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
 using BenchmarkTools: @benchmark

--- a/docs/lit/demos/03/svd-diff.jl
+++ b/docs/lit/demos/03/svd-diff.jl
@@ -11,7 +11,7 @@ by
 #srcURL
 
 #=
-First we add the Julia packages that are need for this demo.
+Add the Julia packages that are need for this demo.
 Change `false` to `true` in the following code block
 if you are using any of the following packages for the first time.
 =#
@@ -27,7 +27,7 @@ if false
 end
 
 
-# Now tell this Julia session to use the following packages for this example.
+# Tell this Julia session to use the following packages for this example.
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
 using InteractiveUtils: versioninfo

--- a/docs/lit/demos/04/ls-cost1.jl
+++ b/docs/lit/demos/04/ls-cost1.jl
@@ -9,7 +9,7 @@ using the Julia language.
 #srcURL
 
 #=
-First we add the Julia packages that are need for this demo.
+Add the Julia packages that are need for this demo.
 Change `false` to `true` in the following code block
 if you are using any of the following packages for the first time.
 =#
@@ -27,7 +27,7 @@ if false
 end
 
 
-# Now tell this Julia session to use the following packages for this example.
+# Tell this Julia session to use the following packages for this example.
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
 using InteractiveUtils: versioninfo

--- a/docs/lit/demos/04/ls-fit1.jl
+++ b/docs/lit/demos/04/ls-fit1.jl
@@ -8,7 +8,7 @@ using the Julia language.
 #srcURL
 
 #=
-First we add the Julia packages that are need for this demo.
+Add the Julia packages that are need for this demo.
 Change `false` to `true` in the following code block
 if you are using any of the following packages for the first time.
 =#
@@ -26,7 +26,7 @@ if false
 end
 
 
-# Now tell this Julia session to use the following packages for this example.
+# Tell this Julia session to use the following packages for this example.
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
 using InteractiveUtils: versioninfo

--- a/docs/lit/demos/05/procrustes.jl
+++ b/docs/lit/demos/05/procrustes.jl
@@ -22,6 +22,7 @@ if false
         "InteractiveUtils"
         "LinearAlgebra"
         "MIRTjim"
+        "Random"
     ])
 end
 
@@ -32,6 +33,7 @@ end
 using InteractiveUtils: versioninfo
 using LinearAlgebra: svd, norm, Diagonal
 using MIRTjim: prompt
+using Random: seed!
 
 
 # The following line is helpful when running this jl-file as a script;
@@ -42,7 +44,7 @@ isinteractive() && prompt(:prompt);
 
 # ## Coordinate data
 
-# coordinates from rotated image example in n-05-norm/fig/
+# Coordinates from rotated image example in Ch. 5 (`n-05-norm/fig/`)
 A = [-59 -25 49;
     6 -33 20]
 B = [-54.1 -5.15 32.44;
@@ -86,7 +88,7 @@ end
 
 # ## Explore additional special cases
 
-# Three points along a line, symmetrical:
+# ### Three points along a line, symmetrical:
 
 A = [-1 0 1; 0 0 0]
 B = [0 0 0; -2 0 2]
@@ -96,7 +98,7 @@ Q, scale = procrustes(A, B)
 @assert B ≈ scale * Q * A
 
 
-# Three points along a line, not symmetrical:
+# ### Three points along a line, not symmetrical:
 
 A = [-1 0 2; 0 0 0]
 B = [0 0 0; -2 0 4]
@@ -106,24 +108,45 @@ Q, scale = procrustes(A, B)
 @assert B ≈ scale * Q * A
 
 
-# A single point - works fine!
+# ### A single point - works fine!
 
 A = [1; 0]
-B = [1; 1]
+B = [2; 2] # different length!
 Q, scale = procrustes(A, B)
 
 # Check:
 @assert B ≈ scale * Q * A
 
 # Angle:
-acos(Q[1]) * 180/π
+rad2deg(acos(Q[1]))
 
 
-#src Q = U * Diagonal([1, 0]) * V'
+# Examine some other options for `Q`
+(U,s,V) = svd(B*A')
+Q1 = U*V'
+@assert B ≈ scale * Q1 * A # same as above
 
-#src todo: examine effect of noise too
+Q2 = U * Diagonal([1, 0]) * V' # (not unitary)
 
-#src prompt()
+#
+@assert B ≈ scale * Q2 * A # also works for this case!
 
+Q3 = U * Diagonal([1, -1]) * V' # is unitary
+
+#
+@assert B ≈ scale * Q3 * A # also works for this case!
+
+
+#=
+## Examine effect of noise
+=#
+seed!(0)
+σ = 0.1
+An = A + σ * randn(size(A))
+Bn = B + σ * randn(size(B))
+Q_n, scale_n = procrustes(An, Bn)
+
+# Angle:
+rad2deg(acos(Q_n[1]))
 
 include("../../../inc/reproduce.jl")

--- a/docs/lit/demos/05/procrustes.jl
+++ b/docs/lit/demos/05/procrustes.jl
@@ -29,7 +29,7 @@ end
 # Tell this Julia session to use the following packages for this example.
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
-using NonDepsPackageJustAsAnExample
+using IOCapture: capture # non-deps package
 using InteractiveUtils: versioninfo
 using LinearAlgebra: svd, norm, Diagonal
 using MIRTjim: prompt

--- a/docs/lit/demos/05/procrustes.jl
+++ b/docs/lit/demos/05/procrustes.jl
@@ -9,7 +9,9 @@ using the Julia language.
 #srcURL
 
 #=
-First we add the Julia packages that are need for this demo.
+## Setup
+
+Add the Julia packages that are need for this demo.
 Change `false` to `true` in the following code block
 if you are using any of the following packages for the first time.
 =#
@@ -24,9 +26,10 @@ if false
 end
 
 
-# Now tell this Julia session to use the following packages for this example.
+# Tell this Julia session to use the following packages for this example.
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
+using NonDepsPackageJustAsAnExample
 using InteractiveUtils: versioninfo
 using LinearAlgebra: svd, norm, Diagonal
 using MIRTjim: prompt

--- a/docs/lit/demos/05/procrustes.jl
+++ b/docs/lit/demos/05/procrustes.jl
@@ -29,7 +29,6 @@ end
 # Tell this Julia session to use the following packages for this example.
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
-using IOCapture: capture # non-deps package
 using InteractiveUtils: versioninfo
 using LinearAlgebra: svd, norm, Diagonal
 using MIRTjim: prompt

--- a/docs/lit/demos/06/lr-sure.jl
+++ b/docs/lit/demos/06/lr-sure.jl
@@ -11,7 +11,7 @@ using the Julia language.
 #srcURL
 
 #=
-First we add the Julia packages that are need for this demo.
+Add the Julia packages that are need for this demo.
 Change `false` to `true` in the following code block
 if you are using any of the following packages for the first time.
 =#
@@ -29,7 +29,7 @@ if false
 end
 
 
-# Now tell this Julia session to use the following packages for this example.
+# Tell this Julia session to use the following packages for this example.
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
 using InteractiveUtils: versioninfo

--- a/docs/lit/demos/06/photometric3.jl
+++ b/docs/lit/demos/06/photometric3.jl
@@ -346,7 +346,7 @@ prompt()
 #=
 ## Estimate surface normals.
 
-Now that we have estimated the lighting directions,
+Having estimated the lighting directions,
 return to estimate the surface normals
 for _all_ pixels,
 not just the "good" pixels.

--- a/docs/lit/demos/06/rank1.jl
+++ b/docs/lit/demos/06/rank1.jl
@@ -8,7 +8,7 @@ using the Julia language.
 #srcURL
 
 #=
-First we add the Julia packages that are need for this demo.
+Add the Julia packages that are need for this demo.
 Change `false` to `true` in the following code block
 if you are using any of the following packages for the first time.
 =#
@@ -25,7 +25,7 @@ if false
 end
 
 
-# Now tell this Julia session to use the following packages for this example.
+# Tell this Julia session to use the following packages for this example.
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
 using InteractiveUtils: versioninfo

--- a/docs/lit/demos/06/source-local.jl
+++ b/docs/lit/demos/06/source-local.jl
@@ -9,7 +9,7 @@ using the Julia language.
 #srcURL
 
 #=
-First we add the Julia packages that are need for this demo.
+Add the Julia packages that are need for this demo.
 Change `false` to `true` in the following code block
 if you are using any of the following packages for the first time.
 =#
@@ -27,7 +27,7 @@ if false
 end
 
 
-# Now tell this Julia session to use the following packages for this example.
+# Tell this Julia session to use the following packages for this example.
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
 using InteractiveUtils: versioninfo

--- a/docs/lit/demos/07/eigmap.jl
+++ b/docs/lit/demos/07/eigmap.jl
@@ -16,7 +16,7 @@ See
 #srcURL
 
 #=
-First we add the Julia packages that are need for this demo.
+Add the Julia packages that are need for this demo.
 Change `false` to `true` in the following code block
 if you are using any of the following packages for the first time.
 =#
@@ -35,7 +35,7 @@ if false
 end
 
 
-# Now tell this Julia session to use the following packages for this example.
+# Tell this Julia session to use the following packages for this example.
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
 using ImagePhantoms: rect, phantom
@@ -138,7 +138,7 @@ prompt()
 #=
 ## Eigenmaps
 
-Now apply one of the Laplacian eigenmap methods.
+Apply one of the Laplacian eigenmap methods.
 First compute the distances between all pairs of data points (images).
 
 There is little if any humanly visible structure

--- a/docs/lit/demos/07/spectral-cluster.jl
+++ b/docs/lit/demos/07/spectral-cluster.jl
@@ -14,7 +14,7 @@ applied to hand-written digits.
 # ### Setup
 
 #=
-First we add the Julia packages that are need for this demo.
+Add the Julia packages that are need for this demo.
 Change `false` to `true` in the following code block
 if you are using any of the following packages for the first time.
 =#
@@ -35,7 +35,7 @@ if false
 end
 
 
-# Now tell this Julia session to use the following packages for this example.
+# Tell this Julia session to use the following packages for this example.
 # Run `Pkg.add()` in the preceding code block first, if needed.
 
 using Clustering: kmeans

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -102,5 +102,6 @@ if isci
         versions = nothing,
         forcepush = true,
         push_preview = true,
+        strict = true, # fail on "warnings"
     )
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,8 @@
 execute = isempty(ARGS) || ARGS[1] == "run"
 
 org, reps = :JeffFessler, "book-mmaj-demo"
-using Documenter
-using Literate
+import Documenter
+import Literate
 
 # https://juliadocs.github.io/Documenter.jl/stable/man/syntax/#@example-block
 ENV["GKSwstype"] = "100"
@@ -73,11 +73,12 @@ format = Documenter.HTML(;
     assets = ["assets/custom.css"],
 )
 
-makedocs(;
+Documenter.makedocs(;
     modules = Module[],
     authors = "Jeff Fessler and contributors",
     sitename = "Demos",
     format,
+    strict = true, # fail on "warnings"
     pages = [
         "Home" => "index.md",
 #       "00 Intro" => demos("00"),
@@ -95,13 +96,12 @@ makedocs(;
 )
 
 if isci
-    deploydocs(;
+    Documenter.deploydocs(;
         repo = "github.com/$base",
         devbranch = "main",
         devurl = "dev",
         versions = nothing,
         forcepush = true,
         push_preview = true,
-        strict = true, # fail on "warnings"
     )
 end


### PR DESCRIPTION
Prior to the changes shown here, a missing package would fail under BuildAndDeploy with a "warning" and then still pass github.  Now fixed thanks to `strict = true` option per
https://github.com/fredrikekre/Literate.jl/issues/212 in docs/make.jl
(The rest of the changes are cosmetic.)
